### PR TITLE
feat: ユーザーのフルネーム取得および更新機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 # local env files
 .vscode/
 .github/copilot-instructions.md
+.cursor

--- a/src/app/api/get-fullname/route.ts
+++ b/src/app/api/get-fullname/route.ts
@@ -1,0 +1,32 @@
+import { sql } from "@vercel/postgres";
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get("userId");
+
+    if (!userId) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+    }
+
+    // Retrieve the hashed fullname from the users table
+    const result = await sql`
+      SELECT fullname FROM users WHERE clerk_user_id = ${userId};
+    `;
+
+    if (result.rowCount === 0) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const hashedFullName = result.rows[0].fullname;
+
+    return NextResponse.json({ hashedFullName });
+  } catch (error) {
+    console.error("GET /api/get-fullname error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/talks/route.ts
+++ b/src/app/api/talks/route.ts
@@ -16,6 +16,7 @@ export async function POST(req: Request) {
       presentation_date,
       venue,
       neonuuid,
+      fullname,
     } = body;
 
     const date_submitted = new Date().toISOString();
@@ -32,7 +33,8 @@ export async function POST(req: Request) {
         image_url,
         presentation_date,
         venue,
-        user_id
+        user_id,
+        fullname
       ) VALUES (
         ${presenter},
         ${email},
@@ -44,7 +46,8 @@ export async function POST(req: Request) {
         ${image_url},
         ${presentation_date},
         ${venue},
-        ${neonuuid}
+        ${neonuuid},
+        ${fullname}
       );
     `;
 

--- a/src/app/api/update-fullname/route.ts
+++ b/src/app/api/update-fullname/route.ts
@@ -1,0 +1,32 @@
+import { sql } from "@vercel/postgres";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const { clerkUserId, neonUserId, newFullName } = await req.json();
+
+    if (!clerkUserId || !neonUserId || !newFullName) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+    }
+
+    await sql`
+      UPDATE users
+      SET fullname = ${newFullName}
+      WHERE clerk_user_id = ${clerkUserId};
+    `;
+
+    await sql`
+      UPDATE talks
+      SET fullname = ${newFullName}
+      WHERE user_id = ${neonUserId};
+    `;
+
+    return NextResponse.json({ message: "Full name updated successfully" });
+  } catch (error) {
+    console.error("POST /api/update-fullname error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/verify/name/page.tsx
+++ b/src/app/verify/name/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { useEffect } from "react";
+import { useAuth, useUser } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import { useUpdateFullname } from "@/hooks/useUpdateFullname";
+import { useUserId } from "@/hooks/useUserId";
+
+const formSchema = z.object({
+  fullName: z
+    .string()
+    .min(2, "フルネームは2文字以上で入力してください")
+    .regex(
+      /^[A-Za-zぁ-んァ-ン一-龯]+\s+[A-Za-zぁ-んァ-ン一-龯]+$/,
+      "姓と名の間にスペースを入れて入力してください"
+    ),
+});
+
+export default function ProfilePage() {
+  const { user } = useUser();
+  const { isSignedIn } = useAuth();
+  const router = useRouter();
+  const { neonid, isLoading: isLoadingUserId } = useUserId();
+  const { updateFullname, isLoading, error: updateError } = useUpdateFullname();
+
+  useEffect(() => {
+    if (isSignedIn === false) {
+      router.push("/");
+      return;
+    }
+
+    const isSIWUser = user?.emailAddresses?.some(
+      (email) =>
+        email.emailAddress.startsWith("siw") &&
+        email.emailAddress.endsWith("@class.siw.ac.jp")
+    );
+
+    if (!isSIWUser) {
+      router.push("/");
+    }
+  }, [isSignedIn, user, router]);
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      fullName: "",
+    },
+  });
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    try {
+      if (!user || !neonid) {
+        throw new Error("ユーザー情報が取得できません。");
+      }
+
+      await updateFullname(user.id, neonid, values.fullName);
+
+      router.push("/register");
+    } catch (error) {
+      console.error("Error updating fullname:", error);
+    }
+  }
+
+  // ローディング状態の表示
+  if (isSignedIn === undefined || !user || isLoadingUserId) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <Button variant="ghost" disabled>
+          <ArrowLeft className="mr-2 h-4 w-4 animate-spin" />
+          Loading...
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <Button variant="ghost" size="sm" asChild className="mb-8">
+        <Link href="/" className="flex items-center gap-2">
+          <ArrowLeft className="h-4 w-4" />
+          ホームに戻る
+        </Link>
+      </Button>
+
+      <div className="max-w-2xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight mb-3">
+              本名の登録
+            </h1>
+            <p className="text-muted-foreground">
+              SIWのユーザーは、ライトニングトークの投稿にあたり本名の登録が必要です。
+            </p>
+          </div>
+        </div>
+
+        <div className="bg-card border border-border rounded-lg p-6">
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+              <FormField
+                control={form.control}
+                name="fullName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>本名（フルネーム）</FormLabel>
+                    <div className="mb-2" />
+                    <FormControl>
+                      <Input {...field} placeholder="例：山田 太郎" />
+                    </FormControl>
+                    <FormDescription>
+                      公的書類に記載されている通りの本名を入力してください。姓と名の間にスペースを入れてください。
+                    </FormDescription>
+                    <FormMessage className="text-red-400 text-sm" />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex justify-end">
+                <Button variant="outline" type="submit" disabled={isLoading}>
+                  {isLoading ? "更新中..." : "登録する"}
+                </Button>
+              </div>
+
+              {updateError && (
+                <div className="p-4">
+                  <p className="text-red-400 text-sm">Error: {updateError}</p>
+                </div>
+              )}
+            </form>
+          </Form>
+        </div>
+
+        <div className="mt-8 p-4 bg-yellow-50 dark:bg-yellow-950 rounded-xl">
+          <h3 className="text-yellow-800 dark:text-yellow-200 font-medium mb-2">
+            重要なお知らせ
+          </h3>
+          <p className="text-yellow-700 dark:text-yellow-300 text-sm">
+            個人情報の取り扱いについては、
+            <Link href="/legal/privacy" className="underline mx-1">
+              プライバシーポリシー
+            </Link>
+            をご参照ください。
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,7 +3,16 @@
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
-import { Zap, Menu, X, Home, List, PlusCircle } from "lucide-react";
+import {
+  Zap,
+  Menu,
+  X,
+  Home,
+  List,
+  PlusCircle,
+  UserRound,
+  Bookmark,
+} from "lucide-react";
 import {
   useUser,
   SignUpButton,
@@ -117,6 +126,7 @@ export default function Navbar() {
                 >
                   Dashboard
                 </Link>
+                <div className="mr-1" />
                 <UserButton />
               </SignedIn>
             </div>
@@ -176,6 +186,22 @@ export default function Navbar() {
             >
               <PlusCircle size={18} />
               <span>Submit Talk</span>
+            </Link>
+            <Link
+              href="/dashboard"
+              onClick={() => setIsMobileMenuOpen(false)}
+              className="flex items-center gap-2 p-2 rounded-md hover:bg-accent"
+            >
+              <Bookmark size={18} />
+              <span>Dashboard</span>
+            </Link>
+            <Link
+              href="/dashboard/profile"
+              onClick={() => setIsMobileMenuOpen(false)}
+              className="flex items-center gap-2 p-2 rounded-md hover:bg-accent"
+            >
+              <UserRound size={18} />
+              <span>Profile</span>
             </Link>
           </nav>
           <SignedOut>

--- a/src/components/talks/TalkCard.tsx
+++ b/src/components/talks/TalkCard.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { motion } from "framer-motion";
 import { Talk } from "@/types/talk";
+import { useUser } from "@clerk/nextjs";
 
 interface TalkCardProps {
   talk: Talk;
@@ -19,6 +20,8 @@ export default function TalkCard({
   variant = "default",
   index = 0,
 }: TalkCardProps) {
+  const { user } = useUser();
+
   const statusColors = {
     pending: "bg-yellow-100 text-yellow-800 border-yellow-200",
     approved: "bg-green-100 text-green-800 border-green-200",
@@ -31,6 +34,18 @@ export default function TalkCard({
     month: "short",
     day: "numeric",
   });
+
+  // ユーザーのメールアドレスとトークのメールアドレスが条件を満たすかチェック
+  const isSIWUser =
+    user?.primaryEmailAddress?.emailAddress &&
+    talk.email &&
+    user.primaryEmailAddress.emailAddress.startsWith("siw") &&
+    user.primaryEmailAddress.emailAddress.endsWith("@class.siw.ac.jp") &&
+    talk.email.startsWith("siw") &&
+    talk.email.endsWith("@class.siw.ac.jp");
+
+  // 表示する名前を決定
+  const displayName = isSIWUser ? talk.fullname : talk.presenter;
 
   return (
     <motion.div
@@ -96,7 +111,7 @@ export default function TalkCard({
 
             <div className="flex items-center justify-between">
               <div className="flex items-center">
-                <div className="text-sm font-medium">{talk.presenter}</div>
+                <div className="text-sm font-medium">{displayName}</div>
               </div>
               <motion.div
                 whileHover={{ x: 5 }}

--- a/src/components/ui/heroSection.tsx
+++ b/src/components/ui/heroSection.tsx
@@ -25,7 +25,7 @@ const stats = [
   { number: "1+", label: "Talks Submitted", color: "text-purple-600" },
   { number: "100+", label: "Topics Covered", color: "text-blue-600" },
   { number: "1+", label: "Speakers", color: "text-teal-600" },
-  { number: "0+", label: "Events Per Year", color: "text-orange-500" },
+  // { number: "0+", label: "Events Per Year", color: "text-orange-500" },
 ];
 
 export default function HeroSection() {
@@ -119,7 +119,7 @@ export default function HeroSection() {
             variants={container}
             initial="hidden"
             animate="show"
-            className="mt-20 grid grid-cols-2 md:grid-cols-4 gap-8 text-center"
+            className="mt-20 grid grid-cols-2 md:grid-cols-3 gap-8 text-center"
           >
             {stats.map((stat, index) => (
               <motion.div

--- a/src/hooks/useGetFullname.ts
+++ b/src/hooks/useGetFullname.ts
@@ -1,0 +1,16 @@
+import useSWR from "swr";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function useGetFullname(userId: string) {
+  const { data, error, isLoading } = useSWR(
+    userId ? `/api/get-fullname?userId=${userId}` : null,
+    fetcher
+  );
+
+  return {
+    fullname: data?.hashedFullName,
+    isLoading,
+    isError: !!error,
+  };
+}

--- a/src/hooks/useUpdateFullname.ts
+++ b/src/hooks/useUpdateFullname.ts
@@ -1,0 +1,48 @@
+import { useState } from "react";
+
+export function useUpdateFullname() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const updateFullname = async (
+    clerkUserId: string,
+    neonUserId: number,
+    newFullName: string
+  ) => {
+    setIsLoading(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const response = await fetch("/api/update-fullname", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          clerkUserId,
+          neonUserId,
+          newFullName,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || "Failed to update fullname");
+      }
+
+      setSuccess(true);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("An unknown error occurred");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { updateFullname, isLoading, error, success };
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -17,6 +17,7 @@ export const SAMPLE_TALKS: Talk[] = [
     presentation_date: "2025-04-28",
     venue: "さいたまIT・WEB専門学校 PBLルーム",
     user_id: 1,
+    fullname: "",
   },
   {
     id: 2,
@@ -34,6 +35,7 @@ export const SAMPLE_TALKS: Talk[] = [
     presentation_date: "2025-04-28",
     venue: "さいたまIT・WEB専門学校 PBLルーム",
     user_id: 2,
+    fullname: "",
   },
   {
     id: 3,
@@ -51,6 +53,7 @@ export const SAMPLE_TALKS: Talk[] = [
     presentation_date: "2025-04-28",
     venue: "さいたまIT・WEB専門学校 PBLルーム",
     user_id: 3,
+    fullname: "",
   },
 ];
 

--- a/src/types/talk.ts
+++ b/src/types/talk.ts
@@ -12,4 +12,5 @@ export type Talk = {
   presentation_date: string;
   venue: string;
   user_id: number;
+  fullname: string;
 };


### PR DESCRIPTION
- 新しいAPIエンドポイントを追加し、ユーザーのフルネームを取得する機能を実装。
- フルネームを更新するためのAPIエンドポイントを追加。
- 登録ページやトークページでフルネームの取得と表示を統合。
- ユーザーインターフェースを改善し、フルネームの登録を促すページを追加。