### PR TITLE
タイムスケジュール機能の追加

### DIFF
--- a/src/app/api/daily-schedule/route.ts
+++ b/src/app/api/daily-schedule/route.ts
@@ -1,0 +1,82 @@
+import { sql } from "@vercel/postgres";
+import { NextRequest, NextResponse } from "next/server";
+import { format } from "date-fns";
+
+// GET: 指定された日付のトークスケジュールを取得
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const date = searchParams.get("date");
+
+    if (!date) {
+      return NextResponse.json(
+        { error: "日付パラメータが必要です" },
+        { status: 400 }
+      );
+    }
+
+    // 日付をYYYY-MM-DD形式に正規化
+    let normalizedDate = date;
+    try {
+      // ISO形式やその他の形式からDateオブジェクトを生成しYYYY-MM-DD形式に変換
+      normalizedDate = format(new Date(date), "yyyy-MM-dd");
+    } catch (e) {
+      console.error("日付正規化エラー:", e);
+      // エラーが発生した場合は元の日付を使用
+    }
+
+    // 正規化された日付でトークを検索
+    const result = await sql`
+      SELECT * FROM talks
+      WHERE DATE(presentation_date) = ${normalizedDate}::DATE
+      AND status = 'approved'
+      ORDER BY presentation_start_time ASC NULLS LAST;
+    `;
+
+    return NextResponse.json(result.rows, { status: 200 });
+  } catch (error) {
+    console.error("GET /api/daily-schedule error:", error);
+    return NextResponse.json(
+      { error: "スケジュールの取得に失敗しました" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST: 複数のトークの開始時刻を一括更新（管理者用）
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { talks } = body;
+
+    if (!Array.isArray(talks) || talks.length === 0) {
+      return NextResponse.json(
+        { error: "更新するトークの配列が必要です" },
+        { status: 400 }
+      );
+    }
+
+    // トランザクションを使用して複数のトークを更新
+    await Promise.all(
+      talks.map(async (talk) => {
+        const { id, presentation_start_time } = talk;
+        await sql`
+          UPDATE talks
+          SET presentation_start_time = ${presentation_start_time}
+          WHERE id = ${id};
+        `;
+      })
+    );
+
+    return NextResponse.json(
+      { message: "スケジュールが更新されました" },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("POST /api/daily-schedule error:", error);
+    return NextResponse.json(
+      { error: "スケジュールの更新に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/schedule-dates/route.ts
+++ b/src/app/api/schedule-dates/route.ts
@@ -1,0 +1,37 @@
+import { sql } from "@vercel/postgres";
+import { NextResponse } from "next/server";
+import { format } from "date-fns";
+
+// GET: スケジュールが存在する日付の一覧を取得する
+export async function GET() {
+  try {
+    // 承認済みトークがある日付の一覧を取得（重複なし）
+    const result = await sql`
+      SELECT DISTINCT presentation_date
+      FROM talks
+      WHERE status = 'approved'
+      ORDER BY presentation_date ASC;
+    `;
+
+    // 結果を日付の配列に変換し、YYYY-MM-DD形式に正規化
+    const dates = result.rows.map((row) => {
+      // ISO形式の日付文字列をYYYY-MM-DD形式に変換
+      let dateStr = row.presentation_date;
+      try {
+        // ISO形式またはその他の形式からDateオブジェクトを生成し、YYYY-MM-DD形式に変換
+        dateStr = format(new Date(dateStr), "yyyy-MM-dd");
+      } catch (e) {
+        console.error("日付変換エラー:", e);
+      }
+      return dateStr;
+    });
+
+    return NextResponse.json(dates, { status: 200 });
+  } catch (error) {
+    console.error("GET /api/schedule-dates error:", error);
+    return NextResponse.json(
+      { error: "スケジュール日付の取得に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  ArrowLeft,
+  Clock,
+  ChevronLeft,
+  ChevronRight,
+  Info,
+} from "lucide-react";
+import Link from "next/link";
+import Image from "next/image";
+import { format, addDays, subDays, parseISO } from "date-fns";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { useDailySchedule } from "@/hooks/useDailySchedule";
+import { useScheduleDates } from "@/hooks/useScheduleDates";
+import { Talk } from "@/types/talk";
+
+export default function SchedulePage() {
+  // 利用可能な日付を取得
+  const { dates, isLoading: isDatesLoading } = useScheduleDates();
+
+  // 初期日付の設定
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [formattedDate, setFormattedDate] = useState<string>("");
+
+  // 初期日付を設定する
+  useEffect(() => {
+    if (dates && dates.length > 0 && !selectedDate) {
+      const initialDate = parseISO(dates[0]);
+      setSelectedDate(initialDate);
+      setFormattedDate(format(initialDate, "yyyy-MM-dd"));
+    }
+  }, [dates, selectedDate]);
+
+  // 選択された日付のスケジュールを取得
+  const { talks, isLoading: isTalksLoading } = useDailySchedule(formattedDate);
+
+  // 前の日に移動
+  const handlePreviousDay = () => {
+    if (!selectedDate) return;
+
+    const prevDate = subDays(selectedDate, 1);
+    setSelectedDate(prevDate);
+    setFormattedDate(format(prevDate, "yyyy-MM-dd"));
+  };
+
+  // 次の日に移動
+  const handleNextDay = () => {
+    if (!selectedDate) return;
+
+    const nextDate = addDays(selectedDate, 1);
+    setSelectedDate(nextDate);
+    setFormattedDate(format(nextDate, "yyyy-MM-dd"));
+  };
+
+  // 特定の日付に直接移動
+  const handleDateSelect = (dateStr: string) => {
+    // 日付文字列をそのままformattedDateに設定
+    setFormattedDate(dateStr);
+    // 日付オブジェクトをselectedDateに設定
+    setSelectedDate(parseISO(dateStr));
+  };
+
+  // 現在実施中のトークかどうかを判定
+  const isLiveTalk = (talk: Talk) => {
+    if (!talk.presentation_start_time) return false;
+
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const talkDate = parseISO(talk.presentation_date);
+    const presentationDay = new Date(
+      talkDate.getFullYear(),
+      talkDate.getMonth(),
+      talkDate.getDate()
+    );
+
+    // 日付が一致するか確認
+    if (today.getTime() !== presentationDay.getTime()) {
+      return false;
+    }
+
+    // 開始時刻の時間と分を取得
+    const [hours, minutes] = talk.presentation_start_time
+      .split(":")
+      .map(Number);
+
+    // 発表開始時刻を作成
+    const startTime = new Date(now);
+    startTime.setHours(hours, minutes, 0, 0);
+
+    // 発表終了時刻を計算（開始時刻 + 発表時間）
+    const endTime = new Date(startTime);
+    endTime.setMinutes(endTime.getMinutes() + talk.duration);
+
+    // 現在時刻が開始時刻と終了時刻の間かどうかを確認
+    return now >= startTime && now <= endTime;
+  };
+
+  // ローディング表示
+  if (isDatesLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="flex flex-col items-center">
+          <Info className="h-10 w-10 animate-spin text-blue-500" />
+          <p className="mt-4 text-lg">スケジュール情報を読み込んでいます...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // 利用可能な日付がない場合
+  if (!isDatesLoading && (!dates || dates.length === 0)) {
+    return (
+      <div className="container mx-auto px-4 py-12">
+        <Button variant="ghost" size="sm" asChild className="mb-8">
+          <Link href="/" className="flex items-center gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            ホームに戻る
+          </Link>
+        </Button>
+
+        <div className="max-w-4xl mx-auto text-center py-12">
+          <h1 className="text-3xl font-bold tracking-tight mb-6">
+            ライトニングトークスケジュール
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            現在予定されているトークはありません
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <Button variant="ghost" size="sm" asChild className="mb-8">
+        <Link href="/" className="flex items-center gap-2">
+          <ArrowLeft className="h-4 w-4" />
+          ホームに戻る
+        </Link>
+      </Button>
+
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold tracking-tight mb-6">
+          ライトニングトークスケジュール
+        </h1>
+
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-4">
+            <Button variant="outline" size="icon" onClick={handlePreviousDay}>
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <div className="text-lg font-medium">
+              {selectedDate ? format(selectedDate, "yyyy年MM月dd日") : ""}
+            </div>
+            <Button variant="outline" size="icon" onClick={handleNextDay}>
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="flex gap-2">
+            {dates.slice(0, 5).map((date) => {
+              // 日付文字列そのものを比較
+              const isSelected = date === formattedDate;
+              return (
+                <Button
+                  key={date}
+                  variant={isSelected ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => handleDateSelect(date)}
+                >
+                  {format(parseISO(date), "MM/dd")}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+
+        {isTalksLoading ? (
+          <div className="flex justify-center py-12">
+            <Info className="h-8 w-8 animate-spin text-blue-500" />
+          </div>
+        ) : talks.length > 0 ? (
+          <div className="space-y-6">
+            {talks.map((talk) => (
+              <Card key={talk.id} className="overflow-hidden">
+                <CardContent className="p-0">
+                  <div className="grid md:grid-cols-3 gap-6">
+                    <div className="relative aspect-video md:aspect-square">
+                      {talk.image_url && (
+                        <Image
+                          src={talk.image_url}
+                          alt={talk.title}
+                          fill
+                          className="object-cover"
+                        />
+                      )}
+                    </div>
+                    <div className="p-6 md:col-span-2">
+                      <div className="flex items-center gap-2 mb-4">
+                        <Badge
+                          variant="outline"
+                          className="bg-purple-50 text-purple-700 border-purple-200"
+                        >
+                          発表時間: {talk.presentation_start_time || "時間未定"}
+                        </Badge>
+                        <Badge variant="outline">{talk.venue}</Badge>
+                        {isLiveTalk(talk) && (
+                          <Badge
+                            variant="destructive"
+                            className="animate-pulse"
+                          >
+                            ライブ配信中
+                          </Badge>
+                        )}
+                      </div>
+
+                      <h3 className="text-xl font-semibold mb-2">
+                        {talk.title}
+                      </h3>
+                      <p className="text-md text-muted-foreground mb-4">
+                        発表者: {talk.fullname || talk.presenter}
+                      </p>
+                      <p className="text-sm text-muted-foreground mb-4">
+                        {talk.description}
+                      </p>
+
+                      <div className="flex items-center text-sm text-muted-foreground mb-6">
+                        <Clock className="h-4 w-4 mr-1" />
+                        <span>{talk.duration} 分</span>
+                        <div className="ml-3 px-2 py-0.5 bg-blue-50 text-blue-700 rounded text-xs">
+                          {talk.topic}
+                        </div>
+                      </div>
+
+                      <Button variant="outline" asChild>
+                        <Link href={`/talk/${talk.id}`}>詳細を見る</Link>
+                      </Button>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12 bg-accent rounded-lg">
+            <p className="text-lg text-muted-foreground">
+              この日に予定されているトークはありません
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -100,6 +100,12 @@ export default function Navbar() {
             >
               Talks
             </Link>
+            <Link
+              href="/schedule"
+              className="text-sm text-foreground/80 hover:text-foreground transition-colors"
+            >
+              Schedule
+            </Link>
             <SignedOut>
               <SignInButton>
                 <button className="ml-3 hover:bg-gray-100 p-2 rounded-md">
@@ -112,7 +118,7 @@ export default function Navbar() {
                 </button>
               </SignUpButton>
             </SignedOut>
-            <div className="ml-1 flex justify-end items-center gap-8 h-16">
+            <div className="flex justify-end items-center gap-8 h-16">
               <SignedIn>
                 <Link
                   href="/register"
@@ -126,7 +132,7 @@ export default function Navbar() {
                 >
                   Dashboard
                 </Link>
-                <div className="mr-1" />
+                <div className="mr-0.5" />
                 <UserButton />
               </SignedIn>
             </div>
@@ -178,6 +184,14 @@ export default function Navbar() {
             >
               <List size={18} />
               <span>Browse Talks</span>
+            </Link>
+            <Link
+              href="/schedule"
+              onClick={() => setIsMobileMenuOpen(false)}
+              className="flex items-center gap-2 p-2 rounded-md hover:bg-accent"
+            >
+              <List size={18} />
+              <span>Time Schedule</span>
             </Link>
             <Link
               href="/register"

--- a/src/hooks/useDailySchedule.ts
+++ b/src/hooks/useDailySchedule.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import useSWR from "swr";
+import { Talk } from "@/types/talk";
+import { useState } from "react";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+/**
+ * 指定された日付のトークスケジュールを取得するためのフック
+ * @param date - YYYY-MM-DD形式の日付
+ * @returns トーク一覧、ローディング状態、エラー状態を含むオブジェクト
+ */
+export function useDailySchedule(date?: string) {
+  const { data, error, isLoading, mutate } = useSWR(
+    date ? `/api/daily-schedule?date=${date}` : null,
+    fetcher
+  );
+
+  return {
+    talks: (data as Talk[]) || [],
+    isLoading,
+    isError: !!error,
+    mutate, // 再フェッチのための関数
+  };
+}
+
+/**
+ * 日付ベースのスケジュール更新用フック
+ * @returns スケジュール更新関数とローディング状態
+ */
+export function useUpdateSchedule() {
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  // 複数のトークの開始時刻を一括更新するための関数
+  const updateSchedule = async (
+    talks: Pick<Talk, "id" | "presentation_start_time">[]
+  ) => {
+    if (!talks || talks.length === 0) return false;
+
+    setIsUpdating(true);
+    try {
+      const response = await fetch("/api/daily-schedule", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ talks }),
+      });
+
+      if (!response.ok) {
+        throw new Error("スケジュールの更新に失敗しました");
+      }
+
+      return true;
+    } catch (error) {
+      console.error("スケジュール更新エラー:", error);
+      return false;
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return { updateSchedule, isUpdating };
+}

--- a/src/hooks/useScheduleDates.ts
+++ b/src/hooks/useScheduleDates.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import useSWR from "swr";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+/**
+ * スケジュールが存在する日付一覧を取得するフック
+ * @returns 日付の配列、ローディング状態、エラー状態を含むオブジェクト
+ */
+export function useScheduleDates() {
+  const { data, error, isLoading } = useSWR("/api/schedule-dates", fetcher);
+
+  return {
+    dates: (data as string[]) || [],
+    isLoading,
+    isError: !!error,
+  };
+}


### PR DESCRIPTION
新しいAPIエンドポイントを追加し、日付に基づくトークスケジュールの取得と更新機能を実装しました。また、スケジュールが存在する日付の一覧を取得するためのフックを作成し、スケジュールページを追加しました。ナビゲーションバーにスケジュールページへのリンクも追加しました。

#39